### PR TITLE
Early implementation of naturally spawning bionics.

### DIFF
--- a/DimensionalIntertwinementCore/ItemGroups/Bionics/BionicSpawns.json
+++ b/DimensionalIntertwinementCore/ItemGroups/Bionics/BionicSpawns.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "item_group",
+    "id": "hospital_medical_items",
+    "subtype": "distribution",
+    "copy-from": "hospital_medical_items",
+    "extend": { "entries": [ { "group": "bionics_common", "prob": 5 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "army_personal_locker",
+    "subtype": "distribution",
+    "copy-from": "army_personal_locker",
+    "extend": { "entries": [ { "group": "bionics_mil", "prob": 1 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "xedra_kill_team_set",
+    "subtype": "collection",
+    "copy-from": "xedra_kill_team_set",
+    "extend": { "entries": [ { "group": "bionics_mil", "prob": 3 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "science",
+    "subtype": "distribution",
+    "copy-from": "science",
+    "extend": { "entries": [ { "group": "bionics", "prob": 1 } ] }
+  },
+  {
+    "type": "item_group",
+    "id": "teleport",
+    "subtype": "distribution",
+    "copy-from": "science",
+    "extend": { "entries": [ { "item": "bio_teleport", "prob": 1 } ] }
+  },
+
+]


### PR DESCRIPTION
# THE PROBLEM.
Bionics should spawn naturally as per our lore, in vanilla Dark Days Ahead, they do not. This PR adds bionics to some spawn groups.

This is not currently playtested, so there may be too many/too few bionics, I will be playtesting this myself and going through to see how it feels.

Right now, the general takeaway is that there is a small chance for hospitals to spawn "common" bionics, a small chance for the army lockers and xedra kill team sets to spawn military bionics, (kill team set spawn might be removed) a small chance for the science group to spawn bionics in general, and a small chance for the teleport group to spawn a teleporter bionic.